### PR TITLE
Fix various open issues

### DIFF
--- a/src/main/java/dev/jvfs/EscapeCrystalConfig.java
+++ b/src/main/java/dev/jvfs/EscapeCrystalConfig.java
@@ -101,10 +101,21 @@ public interface EscapeCrystalConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "autoTeleTimerWhenInactive",
+            name = "Show infobox even when inactive",
+            description = "If active, show the infobox even when the auto-tele function is inactive",
+            position = 7,
+            section = autoTeleTimerSection
+    )
+    default boolean autoTeleTimerWhenInactive() {
+        return false;
+    }
+
+    @ConfigItem(
             keyName = "autoTeleTimerAlertTime",
             name = "Infobox Alert time",
             description = "When the auto-tele timer is below this time (in seconds), the timer will turn a different color. Keep at 0 to disable.",
-            position = 7,
+            position = 8,
             section = autoTeleTimerSection
     )
     default int autoTeleTimerAlertTime() {
@@ -115,7 +126,7 @@ public interface EscapeCrystalConfig extends Config {
             keyName = "autoTeleTimerAlertColor",
             name = "Infobox Alert color",
             description = "The color of the timer when auto-tele is active",
-            position = 8,
+            position = 9,
             section = autoTeleTimerSection
     )
     default Color autoTeleTimerAlertColor() {
@@ -126,7 +137,7 @@ public interface EscapeCrystalConfig extends Config {
             keyName = "autoTeleNotification",
             name = "Auto-tele notification warning",
             description = "Triggers a notification when the warning time before teleporting is reached",
-            position = 9,
+            position = 10,
             section = autoTeleTimerSection
     )
     default boolean autoTeleNotification() {

--- a/src/main/java/dev/jvfs/EscapeCrystalConfig.java
+++ b/src/main/java/dev/jvfs/EscapeCrystalConfig.java
@@ -154,4 +154,15 @@ public interface EscapeCrystalConfig extends Config {
     default boolean autoTeleNotificationInCombat() {
         return false;
     }
+
+    @ConfigItem(
+            keyName = "notifyGauntletWithoutCrystal",
+            name = "Notify when entering Gauntlet without crystal",
+            description = "Triggers a notification when entering the Gauntlet without an escape crystal",
+            position = 12,
+            section = autoTeleTimerSection
+    )
+    default boolean notifyGauntletWithoutCrystal() {
+        return true;
+    }
 }

--- a/src/main/java/dev/jvfs/EscapeCrystalConfig.java
+++ b/src/main/java/dev/jvfs/EscapeCrystalConfig.java
@@ -143,4 +143,15 @@ public interface EscapeCrystalConfig extends Config {
     default boolean autoTeleNotification() {
         return false;
     }
+
+    @ConfigItem(
+            keyName = "autoTeleNotificationInCombat",
+            name = "Only notify in combat",
+            description = "If active, will onyl send auto-tele notification warnings if you are in combat",
+            position = 11,
+            section = autoTeleTimerSection
+    )
+    default boolean autoTeleNotificationInCombat() {
+        return false;
+    }
 }

--- a/src/main/java/dev/jvfs/EscapeCrystalOverlay.java
+++ b/src/main/java/dev/jvfs/EscapeCrystalOverlay.java
@@ -27,7 +27,7 @@ public class EscapeCrystalOverlay extends WidgetItemOverlay {
         this.config = config;
         this.plugin = plugin;
         showOnInventory();
-        showOnBank();
+        showOnEquipment();
     }
 
     @Override

--- a/src/main/java/dev/jvfs/EscapeCrystalPlugin.java
+++ b/src/main/java/dev/jvfs/EscapeCrystalPlugin.java
@@ -187,9 +187,8 @@ public class EscapeCrystalPlugin extends Plugin {
         }
 
         int autoTeleTimer = Integer.parseInt(autoTeleTimerValue);
-        final int durationMillis = Constants.CLIENT_TICK_LENGTH * ((autoTeleTimer * 50) - getIdleTicks()) + 999;
 
-        return durationMillis;
+        return Constants.CLIENT_TICK_LENGTH * ((autoTeleTimer * 50) - getIdleTicks()) + 999;
     }
 
     private void removeAutoTeleTimer() {

--- a/src/main/java/dev/jvfs/EscapeCrystalPlugin.java
+++ b/src/main/java/dev/jvfs/EscapeCrystalPlugin.java
@@ -166,6 +166,9 @@ public class EscapeCrystalPlugin extends Plugin {
             createAutoTeleTimer(Duration.ofMillis(durationMillis));
 
             if (config.autoTeleNotification() && this.hasEscapeCrystal() && !notifiedThisTimer && durationMillis <= (config.autoTeleTimerAlertTime() * 1000)) {
+                if (config.autoTeleNotificationInCombat() && !this.isInCombat()) {
+                    return;
+                }
                 notifier.notify("Escape Crystal about to trigger");
                 notifiedThisTimer = true;
             }
@@ -189,6 +192,10 @@ public class EscapeCrystalPlugin extends Plugin {
         int autoTeleTimer = Integer.parseInt(autoTeleTimerValue);
 
         return Constants.CLIENT_TICK_LENGTH * ((autoTeleTimer * 50) - getIdleTicks()) + 999;
+    }
+
+    private boolean isInCombat() {
+        return client.getLocalPlayer().getHealthScale() != -1;
     }
 
     private void removeAutoTeleTimer() {

--- a/src/main/java/dev/jvfs/EscapeCrystalPlugin.java
+++ b/src/main/java/dev/jvfs/EscapeCrystalPlugin.java
@@ -165,7 +165,7 @@ public class EscapeCrystalPlugin extends Plugin {
         if (lastIdleDuration == -1 || durationMillis < lastIdleDuration) {
             createAutoTeleTimer(Duration.ofMillis(durationMillis));
 
-            if (config.autoTeleNotification() && !notifiedThisTimer && durationMillis <= (config.autoTeleTimerAlertTime() * 1000)) {
+            if (config.autoTeleNotification() && this.hasEscapeCrystal() && !notifiedThisTimer && durationMillis <= (config.autoTeleTimerAlertTime() * 1000)) {
                 notifier.notify("Escape Crystal about to trigger");
                 notifiedThisTimer = true;
             }

--- a/src/main/java/dev/jvfs/EscapeCrystalPlugin.java
+++ b/src/main/java/dev/jvfs/EscapeCrystalPlugin.java
@@ -104,11 +104,13 @@ public class EscapeCrystalPlugin extends Plugin {
     public boolean hasEscapeCrystal() {
         ItemContainer inventory = client.getItemContainer(InventoryID.INVENTORY);
 
-        if (inventory != null) {
-            return inventory.contains(ItemID.ESCAPE_CRYSTAL);
+        if (inventory != null && inventory.contains(ItemID.ESCAPE_CRYSTAL)) {
+            return true;
         }
 
-        return false;
+        ItemContainer equipment = client.getItemContainer(InventoryID.EQUIPMENT);
+
+        return equipment != null && equipment.contains(ItemID.ESCAPE_CRYSTAL);
     }
 
     private void setEscapeCrystalStatus(EscapeCrystalOverlay.AutoTeleStatus status, int duration) {

--- a/src/main/java/dev/jvfs/EscapeCrystalTimer.java
+++ b/src/main/java/dev/jvfs/EscapeCrystalTimer.java
@@ -26,6 +26,13 @@ public class EscapeCrystalTimer extends InfoBox {
 
     @Override
     public String getText() {
+        if (this.plugin.getAutoTeleStatus() == EscapeCrystalOverlay.AutoTeleStatus.INACTIVE) {
+            // Using 'config.autoTeleInactiveText' could result in overflowing off the infobox
+            return "Off";
+        } else if (this.plugin.getAutoTeleStatus() == EscapeCrystalOverlay.AutoTeleStatus.UNKNOWN) {
+            return "?";
+        }
+
         Duration timeLeft = Duration.between(Instant.now(), endTime);
 
         int seconds = (int) (timeLeft.toMillis() / 1000L);
@@ -59,6 +66,6 @@ public class EscapeCrystalTimer extends InfoBox {
     public boolean render() {
         return config.autoTeleTimer() &&
                 plugin.hasEscapeCrystal() &&
-                this.plugin.getAutoTeleStatus() == EscapeCrystalOverlay.AutoTeleStatus.ACTIVE;
+                (this.plugin.getAutoTeleStatus() == EscapeCrystalOverlay.AutoTeleStatus.ACTIVE || config.autoTeleTimerWhenInactive());
     }
 }


### PR DESCRIPTION
- **Features**
  - Add setting to show the crystal infobox even if auto-tele is inactive (closes #6)
  - Add setting to only send auto-tele notifications when in combat (closes #7)
- **Bug Fixes**
  - Only send notifications if escape crystal is in inventory/equipped/active when in gauntlet (closes #5)
  - Make the plugin work if the escape crystal is equipped (closes #8)
  - Make the plugin work inside the gauntlet (if entered with an active crystal)
    - Also added a setting (turned on by default) to send a warning notification if the player has entered the Gauntlet lobby without an active escape crystal
 